### PR TITLE
Remove '/success' route

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,14 +35,6 @@ class ApplicationController < Sinatra::Base
     ##your code here
   end
 
-  get "/success" do
-    if logged_in?
-      erb :success
-    else
-      redirect "/login"
-    end
-  end
-
   get "/failure" do
     erb :failure
   end


### PR DESCRIPTION
The "success" route doesn't seem to be used anywhere in the code, and the tests pass without it.